### PR TITLE
Fix dual logging and make Claude errors ultra-compact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-hooks-cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-hooks-cli",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-hooks-cli",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Claude Code hooks - Run validation and quality checks in Claude",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-hooks-cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Claude Code hooks - Run validation and quality checks in Claude",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Restored local file logging that stopped working after adding Claude error context
- Made Claude error messages ultra-compact (single line) to reduce vertical space
- Added actionable guidance in error messages based on error type

## Changes
1. **Local Logging Fix**: All hook executions now write to `~/.local/share/claude-hooks/logs/hooks.log` regardless of settings
2. **Compact Errors**: Claude sees single-line errors with inline guidance instead of verbose multi-line dumps
3. **Smart Actions**: Error messages provide specific actions based on error type (missing deps, npm issues, permissions, etc.)

## Examples of New Format
```
Hook 'test' failed (exit 1) - Check hook arguments: Usage: test.sh <content>
Hook 'build' failed (exit 1) - Run npm install: npm ERR\! Missing dependencies
Hook 'lint' failed (exit 1) - Check file permissions: Error: permission denied
Hook 'security' failed (exit 1): SECURITY WARNING: Detected hardcoded API key in config.js:24
```

## Test Plan
- [x] Verify local logging works (`cat ~/.local/share/claude-hooks/logs/hooks.log`)
- [x] Test various error types show compact messages
- [x] Confirm both logging mechanisms work together
- [x] Check that successful hooks are logged locally

🤖 Generated with [Claude Code](https://claude.ai/code)